### PR TITLE
add type: AnimeMovie to StreamPlay

### DIFF
--- a/StreamPlay/build.gradle.kts
+++ b/StreamPlay/build.gradle.kts
@@ -57,7 +57,8 @@ cloudstream {
         "TvSeries",
         "Anime",
         "Movie",
-        "Cartoon"
+        "Cartoon",
+        "AnimeMovie"
     )
 
     iconUrl = "https://i3.wp.com/yt3.googleusercontent.com/ytc/AIdro_nCBArSmvOc6o-k2hTYpLtQMPrKqGtAw_nC20rxm70akA=s900-c-k-c0x00ffffff-no-rj?ssl=1"


### PR DESCRIPTION
the normal StreamPlay catalog doesn't have any anime movies listed,but now StreamPlay-anime (AniList) catalog is added which also has Anime Movies so StreamPlay also qualifies as a Anime movie extension