### PR TITLE
AnimeWorld domain extension updated

### DIFF
--- a/AnimeWorld/build.gradle.kts
+++ b/AnimeWorld/build.gradle.kts
@@ -1,4 +1,4 @@
-version = 10
+version = 11
 
 
 cloudstream {

--- a/AnimeWorld/src/main/kotlin/com/Phisher98/AnimeWorld.kt
+++ b/AnimeWorld/src/main/kotlin/com/Phisher98/AnimeWorld.kt
@@ -24,7 +24,7 @@ import com.lagradost.cloudstream3.utils.Qualities
 import org.jsoup.nodes.Element
 
 class AnimeWorld : MainAPI() {
-    override var mainUrl = "https://anime-world.in"
+    override var mainUrl = "https://anime-world.co"
     override var name = "AnimeWorld"
     override val hasMainPage = true
     override var lang = "hi"


### PR DESCRIPTION
The domain [anime-world.in](https://anime-world.in) now redirects to [anime-world.co](https://anime-world.co)