### PR TITLE
Update Pastebin URL from /raw/ to /dl/ for Password Changes

### DIFF
--- a/AnimeDekhoProvider/build.gradle.kts
+++ b/AnimeDekhoProvider/build.gradle.kts
@@ -1,4 +1,4 @@
-version = 49
+version = 50
 
 cloudstream {
     language = "hi"

--- a/AnimeDekhoProvider/src/main/kotlin/com/Phisher98/Extractor.kt
+++ b/AnimeDekhoProvider/src/main/kotlin/com/Phisher98/Extractor.kt
@@ -76,11 +76,9 @@ open class Raretoon : Chillx() {
     override val requiresReferer = true
 }
 
-// @PlayerX, Nice choice with Diffie-Hellman! 🔐
-// At this point, you're not even a security challenge... you're just my warm-up exercise.
-// Keep trying, maybe one day you’ll at least trigger my firewall.
-// 23rd attempt at cracking you—haha! 💥😂
-// Contact: businesshackerindia@gmail.com 📧
+// Original Code: https://github.com/yogesh-hacker/MediaVanced/blob/main/sites/vidstream.py
+// @PlayerX, After a long time!! with OG methods
+// 26th attempt, I love you! :)
 
 open class Chillx : ExtractorApi() {
     override val name = "Chillx"
@@ -110,8 +108,9 @@ open class Chillx : ExtractorApi() {
                 throw Exception("Encoded string not found")
             }
 
-            val keyUrl = "https://pastebin.com/raw/DCmJyUSi"
-            val passwordHex = app.get(keyUrl).text
+            // Get Password from pastebin(Shareable, Auto-Update)
+            val keyUrl = "https://pastebin.com/dl/DCmJyUSi"
+            val passwordHex = app.get(keyUrl, headers = mapOf("Referer" to "https://pastebin.com/")).text
             val password = passwordHex.chunked(2).map { it.toInt(16).toChar() }.joinToString("")
             val decryptedData = decryptAESCBC(encodedString, password)
                 ?: throw Exception("Decryption failed")

--- a/Anisaga/build.gradle.kts
+++ b/Anisaga/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 44
+version = 45
 
 
 cloudstream {

--- a/Anisaga/src/main/kotlin/com/Anisaga/Extractors.kt
+++ b/Anisaga/src/main/kotlin/com/Anisaga/Extractors.kt
@@ -66,8 +66,8 @@ open class Chillx : ExtractorApi() {
             }
 
             // Get Password from pastebin(Shareable, Auto-Update)
-            val keyUrl = "https://pastebin.com/raw/DCmJyUSi"
-            val passwordHex = app.get(keyUrl).text
+            val keyUrl = "https://pastebin.com/dl/DCmJyUSi"
+            val passwordHex = app.get(keyUrl, headers = mapOf("Referer" to "https://pastebin.com/")).text
             val password = passwordHex.chunked(2).map { it.toInt(16).toChar() }.joinToString("")
 
             // Decrypt using password String


### PR DESCRIPTION
Replaced the Pastebin URL endpoint from `/raw/` to `/dl/` to ensure the latest content is always fetched when handling password changes. This update avoids caching issues and reflects real-time edits made to the paste.
