### PR TITLE
Update HiAnime.kt

### DIFF
--- a/HiAnime/src/main/kotlin/com/HiAnime/HiAnime.kt
+++ b/HiAnime/src/main/kotlin/com/HiAnime/HiAnime.kt
@@ -44,7 +44,7 @@ import java.net.URI
 import kotlin.math.roundToInt
 
 class HiAnime : MainAPI() {
-    override var mainUrl = "https://hianimez.to"
+    override var mainUrl = "https://hianime.to"
     override var name = "HiAnime"
     override val hasQuickSearch = false
     override val hasMainPage = true


### PR DESCRIPTION
The URL of hianime was changed back to hianime.to from hianimez.to. The main site is back up. This commit changes the URL to point back to the main site.