### PR TITLE
Fix SuperStream source name for priority sorting

### DIFF
--- a/StreamPlay/src/main/kotlin/com/Phisher98/StreamPlayUtils.kt
+++ b/StreamPlay/src/main/kotlin/com/Phisher98/StreamPlayUtils.kt
@@ -2056,7 +2056,7 @@ suspend fun invokeExternalSource(
 
                 callback.invoke(
                     ExtractorLink(
-                        "⌜ SuperStream ⌟ ${source.size}",
+                        "⌜ SuperStream ⌟",
                         "⌜ SuperStream ⌟ [Server ${index + 1}] ${source.size}",
                         source.file?.replace("\\/", "/") ?: return@org,
                         "",

--- a/SuperStream/src/main/kotlin/com/phisher98/SuperStreamExtractor.kt
+++ b/SuperStream/src/main/kotlin/com/phisher98/SuperStreamExtractor.kt
@@ -129,7 +129,7 @@ object SuperStreamExtractor : SuperStream() {
                     if (!(source.label == "AUTO" || format == ExtractorLinkType.VIDEO)) return@org
                     callback.invoke(
                         ExtractorLink(
-                            "⌜ SuperStream ⌟ ${source.size}",
+                            "⌜ SuperStream ⌟",
                             "⌜ SuperStream ⌟ [Server ${index + 1}] ${source.size}",
                             source.file?.replace("\\/", "/") ?: return@org,
                             "",


### PR DESCRIPTION
Removes the specific file info from the source name. The full info is still visible in the display name from source list.

Couldn't directly test it as I'm missing private build environment variables.

However this is the working approach for `DahmerMovies` in StreamPlay: https://github.com/phisher98/cloudstream-extensions-phisher/blob/016eebf4b1f5554e2a1308cbb88590742475b4f2/StreamPlay/src/main/kotlin/com/Phisher98/StreamPlayExtractor.kt#L2956-L2958

![Screenshot_20250625_224808_CloudStream Beta](https://github.com/user-attachments/assets/9d52d27f-d2c4-4abb-aef0-bc61c1e75643)
![Screenshot_20250625_224754_CloudStream Beta](https://github.com/user-attachments/assets/10da22a8-c491-48a2-a457-bb4e74f0f379)
