### PR TITLE
update StremioAddon

### DIFF
--- a/StremioAddon/build.gradle.kts
+++ b/StremioAddon/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.konan.properties.Properties
 
-// use an integer for version numbers
-version = 1
+version = 6
 
 android {
     buildFeatures {
@@ -19,7 +18,7 @@ android {
 cloudstream {
     language = "en"
 
-     description = "[!] Requires Setup \n- Allows you to use any Stremio addon by pasting their manifest.json url"
+     description = "[!] Requires Setup \n- Allows you to use any Stremio addon by pasting their manifest.json url\n- Supports 5 addon urls"
      authors = listOf("Hexated,phisher98,erynith")
 
     /**
@@ -33,7 +32,6 @@ cloudstream {
     tvTypes = listOf(
         "TvSeries",
         "Movie",
-        "AsianDrama",
         "Torrent"
     )
     requiresResources = true

--- a/StremioAddon/src/main/kotlin/com/phisher98/settings/SettingsFragment.kt
+++ b/StremioAddon/src/main/kotlin/com/phisher98/settings/SettingsFragment.kt
@@ -56,10 +56,30 @@ class SettingsFragment(
     ): View {
         val root = getLayout("settings", inflater, container)
 
-        // ===== ADDON =====
+        // ===== ADDON 1 =====
         val stremioAddonInput = root.findView<EditText>("stremio_addon_input")
         stremioAddonInput.setText(sharedPref.getString("stremio_addon", ""))
         stremioAddonInput.makeTvCompatible()
+
+        // ===== ADDON 2 =====
+        val stremioAddon2Input = root.findView<EditText>("stremio_addon2_input")
+        stremioAddon2Input.setText(sharedPref.getString("stremio_addon2", ""))
+        stremioAddon2Input.makeTvCompatible()
+
+        // ===== ADDON 3 =====
+        val stremioAddon3Input = root.findView<EditText>("stremio_addon3_input")
+        stremioAddon3Input.setText(sharedPref.getString("stremio_addon3", ""))
+        stremioAddon3Input.makeTvCompatible()
+
+        // ===== ADDON 4 =====
+        val stremioAddon4Input = root.findView<EditText>("stremio_addon4_input")
+        stremioAddon4Input.setText(sharedPref.getString("stremio_addon4", ""))
+        stremioAddon4Input.makeTvCompatible()
+
+        // ===== ADDON 5 =====
+        val stremioAddon5Input = root.findView<EditText>("stremio_addon5_input")
+        stremioAddon5Input.setText(sharedPref.getString("stremio_addon5", ""))
+        stremioAddon5Input.makeTvCompatible()
 
         // ===== SAVE =====
         val saveBtn = root.findView<ImageView>("save")
@@ -68,6 +88,10 @@ class SettingsFragment(
         saveBtn.setOnClickListener {
             sharedPref.edit {
                 putString("stremio_addon", stremioAddonInput.text.toString())
+                putString("stremio_addon2", stremioAddon2Input.text.toString())
+                putString("stremio_addon3", stremioAddon3Input.text.toString())
+                putString("stremio_addon4", stremioAddon4Input.text.toString())
+                putString("stremio_addon5", stremioAddon5Input.text.toString())
             }
 
             AlertDialog.Builder(requireContext())
@@ -96,6 +120,10 @@ class SettingsFragment(
                 .setPositiveButton("Reset") { _, _ ->
                     sharedPref.edit().clear().commit()
                     stremioAddonInput.text.clear()
+                    stremioAddon2Input.text.clear()
+                    stremioAddon3Input.text.clear()
+                    stremioAddon4Input.text.clear()
+                    stremioAddon5Input.text.clear()
                     restartApp()
                 }
                 .setNegativeButton("Cancel", null)

--- a/StremioAddon/src/main/res/layout/settings.xml
+++ b/StremioAddon/src/main/res/layout/settings.xml
@@ -34,16 +34,68 @@
                 android:padding="5dp" />
         </LinearLayout>
 
-        <!-- Stremio Addon URL -->
+        <!-- Stremio Addon 1 Manifest -->
         <EditText
             android:id="@+id/stremio_addon_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Enter Addon Manifest URL"
+            android:hint="Enter Addon 1 Manifest URL"
             android:inputType="text"
             android:padding="8dp"
             android:layout_marginTop="5dp"
             android:focusable="true"
+            android:nextFocusDown="@id/stremio_addon2_input" />
+
+        <!-- Stremio Addon 2 Manifest -->
+        <EditText
+            android:id="@+id/stremio_addon2_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Enter Addon 2 Manifest URL"
+            android:inputType="text"
+            android:padding="8dp"
+            android:layout_marginTop="5dp"
+            android:focusable="true"
+            android:nextFocusUp="@id/stremio_addon_input"
+            android:nextFocusDown="@id/stremio_addon3_input" />
+
+        <!-- Stremio Addon 3 Manifest -->
+        <EditText
+            android:id="@+id/stremio_addon3_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Enter Addon 3 Manifest URL"
+            android:inputType="text"
+            android:padding="8dp"
+            android:layout_marginTop="5dp"
+            android:focusable="true"
+            android:nextFocusUp="@id/stremio_addon2_input"
+            android:nextFocusDown="@id/stremio_addon4_input" />
+
+        <!-- Stremio Addon 4 Manifest -->
+        <EditText
+            android:id="@+id/stremio_addon4_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Enter Addon 4 Manifest URL"
+            android:inputType="text"
+            android:padding="8dp"
+            android:layout_marginTop="5dp"
+            android:focusable="true"
+            android:nextFocusUp="@id/stremio_addon3_input"
+            android:nextFocusDown="@id/stremio_addon5_input" />
+
+        <!-- Stremio Addon 5 Manifest -->
+        <EditText
+            android:id="@+id/stremio_addon5_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Enter Addon 5 Manifest URL"
+            android:inputType="text"
+            android:padding="8dp"
+            android:layout_marginTop="5dp"
+            android:focusable="true"
+            android:nextFocusUp="@id/stremio_addon4_input"
             android:nextFocusDown="@id/delete_img" />
 
         <!-- Reset Button -->
@@ -54,7 +106,7 @@
             android:text="Reset"
             android:layout_marginTop="20dp"
             android:focusable="true"
-            android:nextFocusUp="@id/stremio_addon_input" />
+            android:nextFocusUp="@id/stremio_addon5_input" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
- now supports 5 addon urls
- mainPageOf code is now somewhat manual which allows for 2 custom rows to be automatically added depending on the month (christmas movies and halloween movies)
- posters/episodes/backdrops will now have a fallback "no image available" image instead of just being blank
- simkl id support using `com.lagradost.cloudstream3.BuildConfig.SIMKL_CLIENT_ID`

I could've supported 10 addon urls but until someone complains about only having 5 the extra work isn't worth it